### PR TITLE
Update K8s provider to help e2e tests pass

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,9 +1,13 @@
 variable "test_config_map" {}
 variable "test_secret" {}
+terraform {
+  required_providers {
+    kubernetes = "1.11.3"
+  }
+}
 
 provider "kubernetes" {
-  host     = "https://10.43.0.1"
-  token    = "${file("/var/run/secrets/kubernetes.io/serviceaccount/token")}"
+  load_config_file = "false"
 }
 resource "kubernetes_config_map" "test-config-map" {
   metadata {


### PR DESCRIPTION
pin version of k8s provider to 1.11.3 and tell it to use local servic…